### PR TITLE
Update debian release to trixie

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Firmware for Raspberry Pi (from official bookworm repo)
+# Firmware for Raspberry Pi (from official trixie repo)
 
 This repository holds bootloader firmware files for the Raspberry Pi, downloaded from https://archive.raspberrypi.org/debian/, for usage by the [gokrazy](https://github.com/gokrazy/gokrazy) project.
 

--- a/cmd/retrieve/main.go
+++ b/cmd/retrieve/main.go
@@ -15,7 +15,6 @@ import (
 	"strings"
 
 	"github.com/blakesmith/ar"
-	"github.com/ulikunitz/xz"
 )
 
 func main() {
@@ -27,7 +26,7 @@ func main() {
 }
 
 const baseURL = "https://archive.raspberrypi.org/debian/"
-const packagesURL = baseURL + "dists/bookworm/main/binary-armhf/Packages.gz"
+const packagesURL = baseURL + "dists/trixie/main/binary-armhf/Packages.gz"
 
 func run() error {
 	dstFolder := filepath.Join(".", "dist")
@@ -38,7 +37,7 @@ func run() error {
 
 	log.Println("checking:", packagesURL)
 	bootLoaderURL := ""
-	bootLoaderPrefix := "Filename: pool/main/r/raspberrypi-firmware/raspberrypi-bootloader_"
+	bootLoaderPrefix := "Filename: pool/main/r/raspi-firmware/raspi-firmware_"
 	version := ""
 	versionPrefix := "Version: "
 	err := fetchAndScanGzTextFile(packagesURL, func(s string) bool {
@@ -93,13 +92,13 @@ func extractFirmwareFiles(debSrc io.Reader, dstFolder string) error {
 		if err != nil {
 			return err
 		}
-		if header.Name == "data.tar.xz" {
+		if header.Name == "data.tar.gz" {
 			dataReader = ar
 			break
 		}
 	}
 
-	r, err := xz.NewReader(dataReader)
+	r, err := gzip.NewReader(dataReader)
 	if err != nil {
 		return err
 	}
@@ -117,9 +116,9 @@ func extractFirmwareFiles(debSrc io.Reader, dstFolder string) error {
 			return err
 		}
 		switch hdr.Typeflag {
-		// case tar.TypeDir:
+		//case tar.TypeDir:
 		case tar.TypeReg, tar.TypeRegA:
-			bootPrefix := "./boot/"
+			bootPrefix := "./usr/lib/raspi-firmware/"
 			if !strings.HasPrefix(hdr.Name, bootPrefix) {
 				continue
 			}

--- a/go.mod
+++ b/go.mod
@@ -4,5 +4,4 @@ go 1.20
 
 require (
 	github.com/blakesmith/ar v0.0.0-20190502131153-809d4375e1fb
-	github.com/ulikunitz/xz v0.5.10
 )


### PR DESCRIPTION
Update debian release to trixie

It might be easier to directly using files from https://github.com/raspberrypi/firmware in feature.